### PR TITLE
fix: accept title notation

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,15 +1,10 @@
 import {expect, test} from '@jest/globals'
-import {getRecordUids, parseSecretsInputs} from '../src/main'
+import {parseSecretsInputs} from '../src/main'
 
 test('Input parsing Ok', () => {
     const parsedInputs = parseSecretsInputs(['BediNKCMG21ztm5xGYgNww/field/login > username'])
     expect(parsedInputs[0].notation).toBe('BediNKCMG21ztm5xGYgNww/field/login')
     expect(parsedInputs[0].destination).toBe('username')
-})
-
-test('Record uid extraction Ok', () => {
-    const recordUids = getRecordUids(parseSecretsInputs(['BediNKCMG21ztm5xGYgNww/field/login > username', 'BediNKCMG21ztm5xGYgNww/field/password > password']))
-    expect(recordUids).toStrictEqual(['BediNKCMG21ztm5xGYgNww'])
 })
 
 test('Input and Destination Splitting Ok', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,14 +45,6 @@ export const parseSecretsInputs = (inputs: string[]): SecretsInput[] => {
     return results
 }
 
-export const getRecordUids = (inputs: SecretsInput[]): string[] => {
-    const set = new Set<string>()
-    for (const input of inputs) {
-        set.add(input.notation.split('/')[0])
-    }
-    return Array.from(set)
-}
-
 const downloadSecretFile = async (file: KeeperFile, destination: string): Promise<void> => {
     const fileData = await downloadFile(file)
     fs.writeFileSync(destination, fileData)
@@ -72,7 +64,7 @@ const run = async (): Promise<void> => {
 
         core.debug('Retrieving Secrets from KSM...')
         const options = {storage: loadJsonConfig(config)}
-        const secrets = await getSecrets(options, getRecordUids(inputs))
+        const secrets = await getSecrets(options)
         core.debug(`Retrieved [${secrets.records.length}] secrets`)
 
         if (secrets.warnings) {


### PR DESCRIPTION
Fix #111.

Removing the getRecordUids from getSecrets it will be able to find for the title too.