### PR TITLE
ci(KSM-1180): add dist-drift check and switch to npm ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,21 @@ jobs:
           node-version-file: '.node-version'
           cache: 'npm'
       - run: |
-          npm install
+          npm ci
       - run: |
           npm run all
+      - name: Verify committed dist/ matches a clean rebuild
+        id: dist-drift
+        run: |
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            echo "::error::dist/ is stale: the committed bundle does not match a rebuild from src/ and package-lock.json. Run 'npm run all' and commit dist/."
+            git status --porcelain dist/
+            git diff --ignore-space-at-eol --stat dist/
+            exit 1
+          fi
+      - name: Upload rebuilt dist/ on drift
+        if: failure() && steps.dist-drift.outcome == 'failure'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: rebuilt-dist
+          path: dist/


### PR DESCRIPTION
## Summary

Hardens the build workflow so a stale committed `dist/` bundle can no longer pass CI:

- `npm install` -> `npm ci`: CI now installs the exact `package-lock.json` graph (and fails when `package.json` and the lockfile are out of sync).
- New step after `npm run all`: fails when the rebuilt `dist/` differs from the committed one, using `git status --porcelain dist/` so untracked files that ncc may emit are caught too.
- On drift, the freshly built `dist/` is uploaded as a workflow artifact (`actions/upload-artifact@v7.0.1`) for inspection.

No change to the action itself: `action.yml`, `src/`, and `dist/` are untouched, so nothing consumer-facing changes and no release is needed. The existing `build` job is modified in place, so required-check names and triggers stay the same.

**Base:** targets `release/v1.3.1` (branch is rebased onto it), so the guard lands together with the v1.3.1 release and reaches master when #165 merges. From that point #165's own CI runs enforce that the v1.3.1 bundle matches its lockfile.

## Why

The action ships as a committed ncc bundle; every runtime dependency is inlined into `dist/index.js` at build time. Today CI rebuilds the bundle (`npm run all` includes `npm run package`) but never compares the result against the committed one, so a PR that updates `package-lock.json` without rebuilding passes CI while the old code keeps shipping. That exact failure mode was flagged during the KSM-1179 audit and PR #165, where the bundle had to be verified manually by fingerprinting it against published undici tarballs.

## Testing

- Local, node 24 (matching `.node-version`): `npm ci && npm run all` passes (123/123 tests) and reproduces the committed `dist/` byte for byte on **both** master and `release/v1.3.1`, so the check is deterministic and green on an honest tree, and the v1.3.1 bundle is confirmed to be built from its lockfile.
- CI positive, master base ([run](https://github.com/Keeper-Security/ksm-action/actions/runs/31515063812/job/93858037686)): the new check executed and passed; the artifact step correctly skipped.
- CI negative ([run](https://github.com/Keeper-Security/ksm-action/actions/runs/31515219789/job/93858566191)): a temporary commit hand-editing `dist/index.js` failed exactly at the "Verify committed dist/ matches a clean rebuild" step, and the `rebuilt-dist` artifact was uploaded. The temporary commit was then dropped from the branch.
- CI positive, rebased onto `release/v1.3.1` ([run](https://github.com/Keeper-Security/ksm-action/actions/runs/31515923912/job/93860908834)): green against the actual v1.3.1 tree.

## Jira

https://keeper.atlassian.net/browse/KSM-1180
